### PR TITLE
[#163] Basic implementation of generating toString

### DIFF
--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/bt/BtGenerateToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/bt/BtGenerateToString.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.bt;
+
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.HasMethodDeclared;
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt.SmtAtomToString;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+/**
+ * Transition which generates {@link Object#toString()} for Atoms.
+ *
+ * @author Kapralov Sergey
+ */
+public class BtGenerateToString extends BtApplyIfMatches {
+    /**
+     * Ctor.
+     */
+    public BtGenerateToString() {
+        super(
+            not(
+                new HasMethodDeclared(
+                    named("toString")
+                )
+            ),
+            new BtGenerateMethod(
+                named("toString"),
+                type -> new SmtAtomToString(type)
+            )
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/plugin/GenerateObjectMethodsPlugin.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/plugin/GenerateObjectMethodsPlugin.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Kapralov Sergey.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin;
+
+import com.pragmaticobjects.oo.atom.anno.Atom;
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.bt.*;
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.AnnotatedAtom;
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ConjunctionMatcher;
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ExplicitlyExtendingAnything;
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.validator.ValAtom;
+
+import static net.bytebuddy.matcher.ElementMatchers.*;
+
+/**
+ * Generates {@link Object#equals(Object)}, {@link Object#hashCode()} and
+ * {@link Object#toString()} methods for all {@link Atom}-annotated classes
+ *
+ * @author Kapralov Sergey
+ */
+public class GenerateObjectMethodsPlugin extends TaskPlugin implements Plugin {
+    /**
+     * Ctor
+     */
+    public GenerateObjectMethodsPlugin() {
+        super(
+            new BtApplyIfMatches(
+                new ConjunctionMatcher<>(
+                    not(isInterface()),
+                    not(isAnnotation()),
+                    not(isSynthetic()),
+                    new AnnotatedAtom(),
+                    not(new ExplicitlyExtendingAnything())
+                ),
+                new BtValidated(
+                    new ValAtom(),
+                    new BtSequence(
+                        new BtGenerateEquals(),
+                        new BtGenerateHashCode(),
+                        new BtGenerateToString()
+                    )
+                )
+            )
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtArray.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtArray.java
@@ -34,14 +34,16 @@ import net.bytebuddy.implementation.bytecode.collection.ArrayFactory;
  * @author Kapralov Sergey
  */
 public class SmtArray implements StackManipulationToken {
+    private final TypeDescription type;
     private final List<StackManipulationToken> members;
 
     /**
-     * Ctor.
-     *
+     * Ctor
+     * @param type Array's type
      * @param members Array members
      */
-    public SmtArray(List<StackManipulationToken> members) {
+    public SmtArray(TypeDescription type, List<StackManipulationToken> members) {
+        this.type = type;
         this.members = members;
     }
 
@@ -50,14 +52,32 @@ public class SmtArray implements StackManipulationToken {
      *
      * @param members Array members
      */
+    public SmtArray(List<StackManipulationToken> members) {
+        this(TypeDescription.OBJECT, members);
+    }
+
+    /**
+     * Ctor
+     * @param type Array's type
+     * @param members Array members
+     */
+    public SmtArray(TypeDescription type, StackManipulationToken... members) {
+        this(type, List.of(members));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param members Array members
+     */
     public SmtArray(StackManipulationToken... members) {
-        this(List.of(members));
+        this(TypeDescription.OBJECT, List.of(members));
     }
 
     @Override
     public final StackManipulation stackManipulation() {
         return members.transform(
-            list -> ArrayFactory.forType(TypeDescription.Generic.OBJECT).withValues(
+            list -> ArrayFactory.forType(type.asGenericType()).withValues(
                 list.map(StackManipulationToken::stackManipulation).toJavaList()
             )
         );

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtArray.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtArray.java
@@ -71,7 +71,7 @@ public class SmtArray implements StackManipulationToken {
      * @param members Array members
      */
     public SmtArray(StackManipulationToken... members) {
-        this(TypeDescription.OBJECT, List.of(members));
+        this(List.of(members));
     }
 
     @Override

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldToString.java
@@ -1,0 +1,51 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.type.TypeDescription;
+
+/**
+ * Places a string, built from a single field, on top of the stack.
+ * Format is "field_name=value"
+ *
+ * @author Kapralov Sergey
+ */
+public class SmtAtomFieldToString extends SmtCombined {
+    /**
+     * Ctor.
+     * @param type Type
+     * @param field Field
+     */
+    public SmtAtomFieldToString(final TypeDescription type, final FieldDescription field) {
+        super(
+            new SmtFieldName(field),
+            new SmtLoadField(field),
+            new SmtInvokeAtomToString(type)
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldsToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldsToString.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ConjunctionMatcher;
+import io.vavr.collection.List;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.constant.TextConstant;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Places string, collected from all stringified Atom fields on to of the stack.
+ */
+public class SmtAtomFieldsToString extends SmtInferred {
+    /**
+     * Ctor.
+     * @param type Atom type
+     */
+    public SmtAtomFieldsToString(TypeDescription type) {
+        super(
+            new Inference(
+                type
+            )
+        );
+    }
+
+    /**
+     * {@link SmtAtomFieldsToString} inference
+     *
+     * @author Kapralov Sergey
+     */
+    private static class Inference implements StackManipulationToken.Inference {
+        private final TypeDescription type;
+
+        /**
+         * Ctor.
+         * @param type Type
+         */
+        public Inference(TypeDescription type) {
+            this.type = type;
+        }
+
+        @Override
+        public final StackManipulationToken stackManipulationToken() {
+            return new SmtCombined(
+                new SmtStatic(
+                    new TextConstant(", ")
+                ),
+                new SmtArray(
+                    new TypeDescription.ForLoadedType(CharSequence.class),
+                    List.of(type)
+                        .flatMap(TypeDescription::getDeclaredFields)
+                        .filter(f -> !f.isStatic())
+                        .map(f -> new SmtAtomFieldToString(type, f))
+                        .toJavaArray(SmtAtomFieldToString.class)
+                ),
+                new SmtInvokeMethod(
+                    new TypeDescription.ForLoadedType(String.class),
+                    new ConjunctionMatcher<>(
+                        ElementMatchers.named("join"),
+                        ElementMatchers.takesArguments(2),
+                        ElementMatchers.takesArgument(0, CharSequence.class),
+                        ElementMatchers.takesArgument(1, CharSequence[].class),
+                        ElementMatchers.returns(String.class)
+                    )
+                )
+            );
+        }
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldsToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldsToString.java
@@ -75,8 +75,9 @@ public class SmtAtomFieldsToString extends SmtInferred {
                     List.of(type)
                         .flatMap(TypeDescription::getDeclaredFields)
                         .filter(f -> !f.isStatic())
-                        .map(f -> new SmtAtomFieldToString(type, f))
-                        .toJavaArray(SmtAtomFieldToString.class)
+                        .<StackManipulationToken>map(f -> new SmtAtomFieldToString(type, f))
+                        .prepend(new SmtAtomTypeToString(type))
+                        .toJavaArray(StackManipulationToken.class)
                 ),
                 new SmtInvokeMethod(
                     new TypeDescription.ForLoadedType(String.class),

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomToString.java
@@ -41,8 +41,6 @@ public class SmtAtomToString extends SmtCombined {
     public SmtAtomToString(TypeDescription type) {
         super(
             new SmtNewStringBuilder(),
-            new SmtTypeName(type),
-            new SmtInvokeStringBuilderAppend(),
             new SmtString("{"),
             new SmtInvokeStringBuilderAppend(),
             new SmtAtomFieldsToString(type),

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomToString.java
@@ -21,45 +21,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
 
-package com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin;
-
-import com.pragmaticobjects.oo.atom.anno.Atom;
-import com.pragmaticobjects.oo.atom.codegen.bytebuddy.bt.*;
-import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.AnnotatedAtom;
 import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ConjunctionMatcher;
-import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ExplicitlyExtendingAnything;
-import com.pragmaticobjects.oo.atom.codegen.bytebuddy.validator.ValAtom;
-
-import static net.bytebuddy.matcher.ElementMatchers.*;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.member.MethodReturn;
+import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * Generates {@link Object#equals(Object)} and {@link Object#hashCode()} methods
- * for all {@link Atom}-annotated classes
+ * {@link Object#equals(Object)} method body for Atoms
  *
  * @author Kapralov Sergey
  */
-public class GenerateEqualsAndHashCodePlugin extends TaskPlugin implements Plugin {
+public class SmtAtomToString extends SmtCombined {
     /**
-     * Ctor
+     * Ctor.
+     * @param type type
      */
-    public GenerateEqualsAndHashCodePlugin() {
+    public SmtAtomToString(TypeDescription type) {
         super(
-            new BtApplyIfMatches(
+            new SmtNewStringBuilder(),
+            new SmtTypeName(type),
+            new SmtInvokeStringBuilderAppend(),
+            new SmtString("{"),
+            new SmtInvokeStringBuilderAppend(),
+            new SmtAtomFieldsToString(type),
+            new SmtInvokeStringBuilderAppend(),
+            new SmtString("}"),
+            new SmtInvokeStringBuilderAppend(),
+            new SmtInvokeMethod(
+                new TypeDescription.ForLoadedType(StringBuilder.class),
                 new ConjunctionMatcher<>(
-                    not(isInterface()),
-                    not(isAnnotation()),
-                    not(isSynthetic()),
-                    new AnnotatedAtom(),
-                    not(new ExplicitlyExtendingAnything())
-                ),
-                new BtValidated(
-                    new ValAtom(),
-                    new BtSequence(
-                        new BtGenerateEquals(),
-                        new BtGenerateHashCode()
-                    )
+                    ElementMatchers.named("toString")
                 )
+            ),
+            new SmtStatic(
+                MethodReturn.of(TypeDescription.STRING)
             )
         );
     }

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomTypeToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomTypeToString.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import net.bytebuddy.description.type.TypeDescription;
+
+/**
+ * Places class name as string on top of the stack.
+ * Format is "@type=classname"
+ *
+ * @author Kapralov Sergey
+ */
+public class SmtAtomTypeToString extends SmtCombined {
+    /**
+     * Ctor.
+     * @param type Type
+     */
+    public SmtAtomTypeToString(final TypeDescription type) {
+        super(
+            new SmtString("@type"),
+            new SmtTypeName(type),
+            new SmtInvokeAtomToString(type)
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtFieldName.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtFieldName.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.constant.TextConstant;
+
+/**
+ * Places a field name on top of the stack
+ *
+ * @author Kapralov Sergey
+ */
+public class SmtFieldName implements StackManipulationToken {
+    private final FieldDescription field;
+
+    /**
+     * Ctor.
+     * @param field Field
+     */
+    public SmtFieldName(FieldDescription field) {
+        this.field = field;
+    }
+
+    @Override
+    public final StackManipulation stackManipulation() {
+        return new TextConstant(field.getName());
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtInvokeAtomToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtInvokeAtomToString.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Kapralov Sergey.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ConjunctionMatcher;
+import com.pragmaticobjects.oo.atom.codegen.javassist.templates.Atoms;
+
+import net.bytebuddy.description.type.TypeDescription;
+
+/**
+ * Generates invocation of method "atom$toString".
+ *
+ * @see Atoms
+ * @author Kapralov Sergey
+ */
+public class SmtInvokeAtomToString extends SmtInvokeMethod {
+    /**
+     * Ctor.
+     *
+     * @param type Type to call method on.
+     */
+    public SmtInvokeAtomToString(final TypeDescription type) {
+        super(
+            type,
+            new ConjunctionMatcher<>(
+                isSynthetic(),
+                named("atom$toString")
+            )
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtInvokeStringBuilderAppend.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtInvokeStringBuilderAppend.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ConjunctionMatcher;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Generates invocation of method {@link StringBuilder#append(Object)}
+ *
+ * @author Kapralov Sergey
+ */
+public class SmtInvokeStringBuilderAppend extends SmtInvokeMethod {
+    /**
+     * Ctor.
+     */
+    public SmtInvokeStringBuilderAppend() {
+        super(
+            new TypeDescription.ForLoadedType(StringBuilder.class),
+            new ConjunctionMatcher<>(
+                ElementMatchers.named("append"),
+                ElementMatchers.takesArguments(1),
+                ElementMatchers.takesArgument(0, Object.class),
+                ElementMatchers.returns(StringBuilder.class)
+            )
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtNewStringBuilder.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtNewStringBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ConjunctionMatcher;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.Duplication;
+import net.bytebuddy.implementation.bytecode.TypeCreation;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Places new instance of StringBuilder on top of the stack
+ *
+ * @author Kapralov Sergey
+ */
+public class SmtNewStringBuilder extends SmtCombined {
+    /**
+     * Ctor.
+     */
+    public SmtNewStringBuilder() {
+        super(
+            new SmtStatic(
+                TypeCreation.of(
+                    new TypeDescription.ForLoadedType(
+                        StringBuilder.class
+                    )
+                )
+            ),
+            new SmtStatic(
+                Duplication.SINGLE
+            ),
+            new SmtInvokeMethod(
+                new TypeDescription.ForLoadedType(StringBuilder.class),
+                new ConjunctionMatcher<>(
+                    ElementMatchers.isDefaultConstructor()
+                )
+            )
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtString.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import net.bytebuddy.implementation.bytecode.constant.TextConstant;
+
+/**
+ * Generates instruction which places certain string on stack
+ *
+ * @author Kapralov Sergey
+ */
+public class SmtString extends SmtStatic {
+    /**
+     * Ctor.
+     * @param string String
+     */
+    public SmtString(String string) {
+        super(
+            new TextConstant(string)
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtTypeName.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtTypeName.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
+
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.constant.TextConstant;
+
+/**
+ * Generates placing certain type's name (String) on stack
+ *
+ * @author Kapralov Sergey
+ */
+public class SmtTypeName implements StackManipulationToken {
+    private final TypeDescription typeDescription;
+
+    /**
+     * Ctor.
+     * @param typeDescription Type description
+     */
+    public SmtTypeName(TypeDescription typeDescription) {
+        this.typeDescription = typeDescription;
+    }
+
+    @Override
+    public final StackManipulation stackManipulation() {
+        return new StackManipulation.Compound(
+            new TextConstant(typeDescription.getName())
+        );
+    }
+}

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/plugin/InlineTemplates.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/plugin/InlineTemplates.java
@@ -57,6 +57,12 @@ public class InlineTemplates implements Plugin {
                 m.setModifiers(AccessFlag.STATIC | AccessFlag.PRIVATE | AccessFlag.SYNTHETIC | AccessFlag.BRIDGE);
                 clazz.addMethod(m);
             }
+            {
+                final CtMethod hashCode = classPool.get(Atoms.class.getName()).getDeclaredMethod("atom$toString");
+                CtMethod m = CtNewMethod.copy(hashCode, "atom$toString", clazz, null);
+                m.setModifiers(AccessFlag.STATIC | AccessFlag.PRIVATE | AccessFlag.SYNTHETIC | AccessFlag.BRIDGE);
+                clazz.addMethod(m);
+            }
         } catch(Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/templates/Atoms.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/templates/Atoms.java
@@ -74,4 +74,8 @@ public class Atoms {
         }
         return result;
     }
+
+    private static String atom$toString(String name, Object value) {
+        return name + "=" + value.toString();
+    }
 }

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/templates/Atoms.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/templates/Atoms.java
@@ -76,6 +76,11 @@ public class Atoms {
     }
 
     private static String atom$toString(String name, Object value) {
-        return name + "=" + value.toString();
+        final boolean annotationPresent = value.getClass().isAnnotationPresent(Atom.class);
+        if(annotationPresent) {
+            return "\"" + name + "\": " + value.toString();
+        } else {
+            return "\"" + name + "\": \"" + value.toString() + "\"";
+        }
     }
 }

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/stage/StandardInstrumentationStage.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/stage/StandardInstrumentationStage.java
@@ -3,7 +3,7 @@ package com.pragmaticobjects.oo.atom.codegen.stage;
 import com.pragmaticobjects.oo.atom.banner.BnnrFromResource;
 import com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin.AnnotateClassesPlugin;
 import com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin.AnnotateInterfacesPlugin;
-import com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin.GenerateEqualsAndHashCodePlugin;
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin.GenerateObjectMethodsPlugin;
 import com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin.ValidateAtomAliases;
 import com.pragmaticobjects.oo.atom.codegen.javassist.plugin.InlineTemplates;
 import com.pragmaticobjects.oo.atom.codegen.javassist.plugin.MakeLambdaBreakers;
@@ -47,7 +47,7 @@ public class StandardInstrumentationStage extends SequenceStage {
             ),
             new ByteBuddyStage(
                 new com.pragmaticobjects.oo.atom.codegen.bytebuddy.plugin.VerbosePlugin(
-                    new GenerateEqualsAndHashCodePlugin()
+                    new GenerateObjectMethodsPlugin()
                 )
             ),
             new ByteBuddyStage(

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/tests/AssertAtomsToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/tests/AssertAtomsToString.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Assert that toString method returns certain result.
+ *
+ * @author Kapralov Sergey
+ */
+public class AssertAtomsToString implements Assertion {
+    private final Object atom;
+    private final String expectedValue;
+
+    /**
+     * Ctor.
+     * @param atom Atom
+     * @param expectedValue Expected value
+     */
+    public AssertAtomsToString(Object atom, String expectedValue) {
+        this.atom = atom;
+        this.expectedValue = expectedValue;
+    }
+
+    @Override
+    public final void check() throws Exception {
+        assertThat(atom.toString()).isEqualTo(expectedValue);
+    }
+}

--- a/atom-basis/src/test/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtArrayTest.java
+++ b/atom-basis/src/test/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtArrayTest.java
@@ -2,6 +2,7 @@ package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
 
 import com.pragmaticobjects.oo.atom.tests.TestCase;
 import com.pragmaticobjects.oo.atom.tests.TestsSuite;
+import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.constant.IntegerConstant;
 import net.bytebuddy.jar.asm.Opcodes;
 
@@ -33,6 +34,39 @@ class SmtArrayTest extends TestsSuite {
                     mv -> {
                         mv.visitInsn(Opcodes.ICONST_3);
                         mv.visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/Object");
+                        mv.visitInsn(Opcodes.DUP);
+                        mv.visitInsn(Opcodes.ICONST_0);
+                        mv.visitInsn(Opcodes.ICONST_1);
+                        mv.visitInsn(Opcodes.AASTORE);
+                        mv.visitInsn(Opcodes.DUP);
+                        mv.visitInsn(Opcodes.ICONST_1);
+                        mv.visitInsn(Opcodes.ICONST_2);
+                        mv.visitInsn(Opcodes.AASTORE);
+                        mv.visitInsn(Opcodes.DUP);
+                        mv.visitInsn(Opcodes.ICONST_2);
+                        mv.visitInsn(Opcodes.ICONST_3);
+                        mv.visitInsn(Opcodes.AASTORE);
+                    }
+                )
+            ),
+            new TestCase(
+                "generates new array of certain type",
+                new AssertTokenToGenerateAByteCode(
+                    new SmtArray(
+                        new TypeDescription.ForLoadedType(Integer.class),
+                        new SmtStatic(
+                            IntegerConstant.forValue(1)
+                        ),
+                        new SmtStatic(
+                            IntegerConstant.forValue(2)
+                        ),
+                        new SmtStatic(
+                            IntegerConstant.forValue(3)
+                        )
+                    ),
+                    mv -> {
+                        mv.visitInsn(Opcodes.ICONST_3);
+                        mv.visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/Integer");
                         mv.visitInsn(Opcodes.DUP);
                         mv.visitInsn(Opcodes.ICONST_0);
                         mv.visitInsn(Opcodes.ICONST_1);

--- a/atom-it/src/test/java/com/pragmaticobjects/oo/atom/it/ToStringTest.java
+++ b/atom-it/src/test/java/com/pragmaticobjects/oo/atom/it/ToStringTest.java
@@ -48,10 +48,14 @@ public class ToStringTest extends TestsSuite {
                         new NotAtom(1, 2),
                         new NotAtom(3, 4)
                     ),
-                    "com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom{" +
-                        "a=1/2, " +
-                        "b=3/4" +
+                    String.join(
+                        "",
+                        "{",
+                        "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom\", ",
+                        "\"a\": \"1/2\", ",
+                        "\"b\": \"3/4\"",
                         "}"
+                    )
                 )
             ),
             new TestCase(
@@ -67,16 +71,22 @@ public class ToStringTest extends TestsSuite {
                             new NotAtom(7, 8)
                         )
                     ),
-                    "com.pragmaticobjects.oo.atom.it.ToStringTest$ComplexAtom{" +
-                        "a=com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom{" +
-                        "a=1/2, " +
-                        "b=3/4" +
-                        "}, " +
-                        "b=com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom{" +
-                        "a=5/6, " +
-                        "b=7/8" +
-                        "}" +
+                    String.join(
+                        "",
+                        "{",
+                        "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$ComplexAtom\", ",
+                        "\"a\": {",
+                        "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom\", ",
+                        "\"a\": \"1/2\", ",
+                        "\"b\": \"3/4\"",
+                        "}, ",
+                        "\"b\": {",
+                        "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom\", ",
+                        "\"a\": \"5/6\", ",
+                        "\"b\": \"7/8\"",
+                        "}",
                         "}"
+                    )
                 )
             )
         );

--- a/atom-it/src/test/java/com/pragmaticobjects/oo/atom/it/ToStringTest.java
+++ b/atom-it/src/test/java/com/pragmaticobjects/oo/atom/it/ToStringTest.java
@@ -1,0 +1,121 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package com.pragmaticobjects.oo.atom.it;
+
+import com.pragmaticobjects.oo.atom.tests.AssertAtomsToString;
+import com.pragmaticobjects.oo.atom.tests.TestCase;
+import com.pragmaticobjects.oo.atom.tests.TestsSuite;
+
+/**
+ * Tests suite for Atoms toString logic.
+ *
+ * @author Kapralov Sergey
+ */
+public class ToStringTest extends TestsSuite {
+    /**
+     * Ctor.
+     */
+    public ToStringTest() {
+        super(
+            new TestCase(
+                "Simple atom case",
+                new AssertAtomsToString(
+                    new SimpleAtom(
+                        new NotAtom(1, 2),
+                        new NotAtom(3, 4)
+                    ),
+                    "com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom{" +
+                        "a=1/2, " +
+                        "b=3/4" +
+                        "}"
+                )
+            ),
+            new TestCase(
+                "Complex atom case",
+                new AssertAtomsToString(
+                    new ComplexAtom(
+                        new SimpleAtom(
+                            new NotAtom(1, 2),
+                            new NotAtom(3, 4)
+                        ),
+                        new SimpleAtom(
+                            new NotAtom(5, 6),
+                            new NotAtom(7, 8)
+                        )
+                    ),
+                    "com.pragmaticobjects.oo.atom.it.ToStringTest$ComplexAtom{" +
+                        "a=com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom{" +
+                        "a=1/2, " +
+                        "b=3/4" +
+                        "}, " +
+                        "b=com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom{" +
+                        "a=5/6, " +
+                        "b=7/8" +
+                        "}" +
+                        "}"
+                )
+            )
+        );
+    }
+
+    //CHECKSTYLE:OFF
+    public static class SimpleAtom {
+        private final NotAtom a;
+        private final NotAtom b;
+
+        public SimpleAtom(NotAtom a, NotAtom b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public static class ComplexAtom {
+        private final SimpleAtom a;
+        private final SimpleAtom b;
+
+        public ComplexAtom(SimpleAtom a, SimpleAtom b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    @com.pragmaticobjects.oo.atom.anno.NotAtom
+    public static class NotAtom {
+        private final int a;
+        private final int b;
+
+        public NotAtom(int a, int b) {
+            this.a = a;
+            this.b = b;
+        }
+
+        @Override
+        public String toString() {
+            return a + "/" + b;
+        }
+    }
+}

--- a/docs/ATOM_SPECIFICATION.md
+++ b/docs/ATOM_SPECIFICATION.md
@@ -2,6 +2,8 @@
 
 *Note: checked items are validated and enforced by Atomizer's current version.*
 
+### Atoms
+
 *Atom interface* is Java interface, annotated with `@oo.atom.anno.Atom` annotation.
 All implementors of the Atom interface must be Atoms. The following requirements are set on
 Atom interfaces:
@@ -30,6 +32,8 @@ constructor per Atom. Atom aliases doesn't have a primary constructor.
 - [ ] Supplementary constructors are constructors, which delegate to another constructors, located either in this class,
 or in parent.
 
+### Atom alias
+
 It is allowed to extend Atom classes. But implementation inheritance is strictly prohibited in Atoms concept, that's why
 classes, inherited from Atoms, must follow this set of requirements:
 - [x] No new fields declaration
@@ -38,6 +42,8 @@ classes, inherited from Atoms, must follow this set of requirements:
 - [x] The only things which are allowed are supplementary constructors
 
 A class which extends Atom and follows the rules above is named *Atom alias*.
+
+### Atom equality semantics
 
 Atoms define a set of requirements on equality. The rules are:
 - [x] Two atoms are equal, if and only if they are instance of the same class and their fields are equal.
@@ -52,4 +58,15 @@ A set of standard Java classes are treated as Atoms. They are:
 - [x] All primitive types and their wrappers
 - [x] `java.util.String`
 
-@todo #165 describe the term Natural Java Atoms explicitly. 
+@todo #165 describe the term Natural Java Atoms explicitly.
+
+### Atom `toString` semantics
+
+For each Atom, `toString` method is reserved to produce stringified internal representation of the Atom structure for
+tracing and debugging purposes. Exact format of `toString` output for Atom is not regulated by this specification and
+can change at any time. Client code should never reason on the output of `toString` from Atom.
+
+`toString` implementation of each Atom must follow this set of rules:
+
+- [x] For two equal Atoms (aka Atoms of the same type and equal set of fields), `toString` must produce equal result.
+- [ ] For two non-equal Atoms, `toString` must produce non-equal result.


### PR DESCRIPTION
Closes #163. For each atom, generates `toString` implementation, collected from the fields toString. Useful for debugging purpose