### PR TITLE
[#231] Updated toString method generation

### DIFF
--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldsToString.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtAtomFieldsToString.java
@@ -75,9 +75,9 @@ public class SmtAtomFieldsToString extends SmtInferred {
                     List.of(type)
                         .flatMap(TypeDescription::getDeclaredFields)
                         .filter(f -> !f.isStatic())
-                        .<StackManipulationToken>map(f -> new SmtAtomFieldToString(type, f))
+                        .<StackManipulationToken>map(SmtAtomFieldToString::new)
                         .prepend(new SmtAtomTypeToString(type))
-                        .toJavaArray(StackManipulationToken.class)
+                        .toJavaArray(i -> new StackManipulationToken[i])
                 ),
                 new SmtInvokeMethod(
                     new TypeDescription.ForLoadedType(String.class),

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtInvokeAtomToStringNatural.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/bytebuddy/smt/SmtInvokeAtomToStringNatural.java
@@ -1,7 +1,7 @@
 /*
- * MIT License
+ * The MIT License
  *
- * Copyright (c) 2018 Kapralov Sergey
+ * Copyright 2017 Kapralov Sergey.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,40 +10,47 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 package com.pragmaticobjects.oo.atom.codegen.bytebuddy.smt;
 
+import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.pragmaticobjects.oo.atom.codegen.bytebuddy.matchers.ConjunctionMatcher;
+import com.pragmaticobjects.oo.atom.codegen.javassist.templates.Atoms;
+
 import net.bytebuddy.description.type.TypeDescription;
 
 /**
- * Places class name as string on top of the stack.
- * Format is "@type=classname"
+ * Generates invocation of method {@link Atoms#atom$toString$natural}.
  *
+ * @see Atoms
  * @author Kapralov Sergey
  */
-public class SmtAtomTypeToString extends SmtCombined {
+public class SmtInvokeAtomToStringNatural extends SmtInvokeMethod {
     /**
      * Ctor.
-     * @param type Type
+     *
+     * @param type Type to call method on.
      */
-    public SmtAtomTypeToString(final TypeDescription type) {
+    public SmtInvokeAtomToStringNatural(final TypeDescription type) {
         super(
-            new SmtString("@type"),
-            new SmtTypeName(type),
-            new SmtInvokeAtomToStringNatural(type)
+            type,
+            new ConjunctionMatcher<>(
+                isSynthetic(),
+                named("atom$toString$natural")
+            )
         );
     }
 }

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/plugin/InlineTemplates.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/plugin/InlineTemplates.java
@@ -38,6 +38,18 @@ import javassist.bytecode.AccessFlag;
  * @author Kapralov Sergey
  */
 public class InlineTemplates implements Plugin {
+    private final boolean stubbedInstrumentation;
+
+    /**
+     * Ctor.
+     * @param stubbedInstrumentation stub calls to {@link System#identityHashCode}. 
+     *        If set to true, 42 integer will be substituted where normally 
+     *        {@link System#identityHashCode} is called
+     */
+    public InlineTemplates(boolean stubbedInstrumentation) {
+        this.stubbedInstrumentation = stubbedInstrumentation;
+    }
+
     @Override
     public final void operateOn(final CtClass clazz, final ClassPool classPool) {
         try {
@@ -60,6 +72,23 @@ public class InlineTemplates implements Plugin {
             {
                 final CtMethod hashCode = classPool.get(Atoms.class.getName()).getDeclaredMethod("atom$toString");
                 CtMethod m = CtNewMethod.copy(hashCode, "atom$toString", clazz, null);
+                m.setModifiers(AccessFlag.STATIC | AccessFlag.PRIVATE | AccessFlag.SYNTHETIC | AccessFlag.BRIDGE);
+                clazz.addMethod(m);
+            }
+            {
+                final CtMethod hashCode = classPool.get(Atoms.class.getName()).getDeclaredMethod("atom$toString$natural");
+                CtMethod m = CtNewMethod.copy(hashCode, "atom$toString$natural", clazz, null);
+                m.setModifiers(AccessFlag.STATIC | AccessFlag.PRIVATE | AccessFlag.SYNTHETIC | AccessFlag.BRIDGE);
+                clazz.addMethod(m);
+            }
+            if(stubbedInstrumentation) {
+                final CtMethod hashCode = classPool.get(Atoms.class.getName()).getDeclaredMethod("atom$hashCode$identity$stub");
+                CtMethod m = CtNewMethod.copy(hashCode, "atom$hashCode$identity", clazz, null);
+                m.setModifiers(AccessFlag.STATIC | AccessFlag.PRIVATE | AccessFlag.SYNTHETIC | AccessFlag.BRIDGE);
+                clazz.addMethod(m);
+            } else {
+                final CtMethod hashCode = classPool.get(Atoms.class.getName()).getDeclaredMethod("atom$hashCode$identity");
+                CtMethod m = CtNewMethod.copy(hashCode, "atom$hashCode$identity", clazz, null);
                 m.setModifiers(AccessFlag.STATIC | AccessFlag.PRIVATE | AccessFlag.SYNTHETIC | AccessFlag.BRIDGE);
                 clazz.addMethod(m);
             }

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/templates/Atoms.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/javassist/templates/Atoms.java
@@ -68,11 +68,23 @@ public class Atoms {
             result = 31 * result;
             if(element != null) {
                 final boolean annotationPresent = element.getClass().isAnnotationPresent(Atom.class);
-                final int hashCode = annotationPresent ? element.hashCode() : System.identityHashCode(element);
+                final int hashCode = annotationPresent ? element.hashCode() : atom$hashCode$identity(element);
                 result = result + (element == null ? 0 : hashCode);
             }
         }
         return result;
+    }
+
+    static int atom$hashCode$identity(Object element) {
+        return System.identityHashCode(element);
+    }
+    
+    static int atom$hashCode$identity$stub(Object element) {
+        return 42;
+    }
+    
+    private static String atom$toString$natural(String name, Object value) {
+        return "\"" + name + "\": \"" + value.toString() + "\"";
     }
 
     private static String atom$toString(String name, Object value) {
@@ -80,7 +92,7 @@ public class Atoms {
         if(annotationPresent) {
             return "\"" + name + "\": " + value.toString();
         } else {
-            return "\"" + name + "\": \"" + value.toString() + "\"";
+            return "\"" + name + "\": \"" + value.getClass().getName() + "#" + atom$hashCode$identity(value) + "\"";
         }
     }
 }

--- a/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/stage/StandardInstrumentationStage.java
+++ b/atom-basis/src/main/java/com/pragmaticobjects/oo/atom/codegen/stage/StandardInstrumentationStage.java
@@ -16,8 +16,10 @@ import com.pragmaticobjects.oo.atom.codegen.javassist.plugin.MakeLambdaBreakers;
 public class StandardInstrumentationStage extends SequenceStage {
     /**
      * Ctor.
+     * 
+     * @param stubbedInstrumentation generates stubbed implementations of certain calls. Useful for testing.
      */
-    public StandardInstrumentationStage() {
+    public StandardInstrumentationStage(boolean stubbedInstrumentation) {
         super(
             new ShowBannerStage(
                 new BnnrFromResource(
@@ -42,7 +44,7 @@ public class StandardInstrumentationStage extends SequenceStage {
             ),
             new JavassistStage(
                 new com.pragmaticobjects.oo.atom.codegen.javassist.plugin.VerbosePlugin(
-                    new InlineTemplates()
+                    new InlineTemplates(stubbedInstrumentation)
                 )
             ),
             new ByteBuddyStage(
@@ -56,5 +58,12 @@ public class StandardInstrumentationStage extends SequenceStage {
                 )
             )
         );
+    }
+    
+    /**
+     * Default ctor.
+     */
+    public StandardInstrumentationStage() {
+        this(false);
     }
 }

--- a/atom-it/pom.xml
+++ b/atom-it/pom.xml
@@ -13,12 +13,10 @@
         <dependency>
             <groupId>com.pragmaticobjects.oo.atom</groupId>
             <artifactId>atom-basis</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency> 
             <groupId>io.vavr</groupId> 
             <artifactId>vavr</artifactId>
-            <version>0.10.0</version>
         </dependency>
     </dependencies>
 
@@ -77,6 +75,9 @@
                             <goal>instrument</goal>
                             <goal>instrument-tests</goal>
                         </goals>
+                        <configuration>
+                            <stubbedInstrumentation>true</stubbedInstrumentation>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/atom-it/src/test/java/com/pragmaticobjects/oo/atom/it/ToStringTest.java
+++ b/atom-it/src/test/java/com/pragmaticobjects/oo/atom/it/ToStringTest.java
@@ -29,6 +29,7 @@ package com.pragmaticobjects.oo.atom.it;
 import com.pragmaticobjects.oo.atom.tests.AssertAtomsToString;
 import com.pragmaticobjects.oo.atom.tests.TestCase;
 import com.pragmaticobjects.oo.atom.tests.TestsSuite;
+import java.util.HashMap;
 
 /**
  * Tests suite for Atoms toString logic.
@@ -52,8 +53,8 @@ public class ToStringTest extends TestsSuite {
                         "",
                         "{",
                         "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom\", ",
-                        "\"a\": \"1/2\", ",
-                        "\"b\": \"3/4\"",
+                        "\"a\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$NotAtom#42\", ",
+                        "\"b\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$NotAtom#42\"",
                         "}"
                     )
                 )
@@ -77,14 +78,27 @@ public class ToStringTest extends TestsSuite {
                         "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$ComplexAtom\", ",
                         "\"a\": {",
                         "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom\", ",
-                        "\"a\": \"1/2\", ",
-                        "\"b\": \"3/4\"",
+                        "\"a\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$NotAtom#42\", ",
+                        "\"b\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$NotAtom#42\"",
                         "}, ",
                         "\"b\": {",
                         "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$SimpleAtom\", ",
-                        "\"a\": \"5/6\", ",
-                        "\"b\": \"7/8\"",
+                        "\"a\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$NotAtom#42\", ",
+                        "\"b\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$NotAtom#42\"",
                         "}",
+                        "}"
+                    )
+                )
+            ),
+            new TestCase(
+                "Atom with a link to itself via non-atom attribute",
+                new AssertAtomsToString(
+                    new AtomWithRecursiveNonAtomLink(),
+                    String.join(
+                        "",
+                        "{",
+                        "\"@type\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$AtomWithRecursiveNonAtomLink\", ",
+                        "\"hashMap\": \"com.pragmaticobjects.oo.atom.it.ToStringTest$AtomWithRecursiveNonAtomLink$AHashMap#42\"",
                         "}"
                     )
                 )
@@ -126,6 +140,21 @@ public class ToStringTest extends TestsSuite {
         @Override
         public String toString() {
             return a + "/" + b;
+        }
+    }
+
+    public static class AtomWithRecursiveNonAtomLink {
+        private final HashMap hashMap;
+
+        public AtomWithRecursiveNonAtomLink() {
+            this.hashMap = new AHashMap(this);
+        }
+        
+        @com.pragmaticobjects.oo.atom.anno.NotAtom
+        private static class AHashMap extends HashMap {
+            public AHashMap(Object that) {
+                put("this", that);
+            }
         }
     }
 }

--- a/atom-maven-plugin/src/main/java/com/pragmaticobjects/oo/atom/maven/InstrumentMojo.java
+++ b/atom-maven-plugin/src/main/java/com/pragmaticobjects/oo/atom/maven/InstrumentMojo.java
@@ -34,7 +34,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import java.nio.file.Paths;
 
 /**
- * Mojo that instruments prodiction code
+ * Mojo that instruments production code
  *
  * @author Kapralov Sergey
  */
@@ -43,10 +43,13 @@ public class InstrumentMojo extends BaseMojo {
     @Parameter(defaultValue = "${project.build.outputDirectory}", required = true, readonly = true)
     protected String outputDirectory;
 
+    @Parameter(defaultValue = "false", required = true, readonly = true)
+    protected boolean stubbedInstrumentation;
+
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
         doInstrumentation(
-            new StandardInstrumentationStage(),
+            new StandardInstrumentationStage(stubbedInstrumentation),
             Paths.get(outputDirectory)
         );
     }

--- a/atom-maven-plugin/src/main/java/com/pragmaticobjects/oo/atom/maven/InstrumentTestsMojo.java
+++ b/atom-maven-plugin/src/main/java/com/pragmaticobjects/oo/atom/maven/InstrumentTestsMojo.java
@@ -43,10 +43,13 @@ public class InstrumentTestsMojo extends BaseMojo {
     @Parameter(defaultValue = "${project.build.testOutputDirectory}", required = true, readonly = true)
     protected String outputDirectory;
 
+    @Parameter(defaultValue = "false", required = true, readonly = true)
+    protected boolean stubbedInstrumentation;
+    
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         doInstrumentation(
-            new StandardInstrumentationStage(),
+            new StandardInstrumentationStage(stubbedInstrumentation),
             Paths.get(outputDirectory)
         );
     }


### PR DESCRIPTION
Closes #231. ToString now generates dump in folowing way:

for each attribute:
- if its type is atom (natural or not), calls toString on the attribute
- if its type is non-atom, generates a special label, consisting of the project's type + result of `System.identityHashCode`.

Also, updated atom-maven-plugin by adding special option `stubbedInstrumentation`, which alters instrumentation process by replacing the call to `System.identityHashCode` to a fixed integer (42). By default, it is false. It must be set to `true` when asserting on `toString` contents of atom in tests.